### PR TITLE
remove 'new' from hooks title

### DIFF
--- a/content/docs/nav.yml
+++ b/content/docs/nav.yml
@@ -106,7 +106,7 @@
       title: דרישות סביבת JS
     - id: glossary
       title: מילון מונחים
-- title: Hooks (חדש)
+- title: Hooks
   isOrdered: true
   items:
       - id: hooks-intro


### PR DESCRIPTION
Hooks are not considered new anymore

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
